### PR TITLE
Modularized Content Encryption

### DIFF
--- a/CryptomatorCryptoLib.xcodeproj/project.pbxproj
+++ b/CryptomatorCryptoLib.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		9E35C4EB24576A3D0006E50C /* CryptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E35C4EA24576A3D0006E50C /* CryptorTests.swift */; };
 		9E44EEA624599C6900A37B01 /* AesSiv.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E44EEA524599C6900A37B01 /* AesSiv.swift */; };
 		9E44EEA92459AB1500A37B01 /* AesSivTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E44EEA724599C7800A37B01 /* AesSivTests.swift */; };
+		9E97DC8D25F77BA40046C83E /* ContentCryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E97DC8C25F77BA40046C83E /* ContentCryptor.swift */; };
 		9E9BB812245412E900F9FF51 /* Cryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E9BB811245412E900F9FF51 /* Cryptor.swift */; };
 		9E9BB8142454708600F9FF51 /* Masterkey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E9BB8132454708600F9FF51 /* Masterkey.swift */; };
 		9E9BB81624558DFF00F9FF51 /* MasterkeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E9BB81524558DFF00F9FF51 /* MasterkeyTests.swift */; };
@@ -90,6 +91,7 @@
 		9E35C4EA24576A3D0006E50C /* CryptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptorTests.swift; sourceTree = "<group>"; };
 		9E44EEA524599C6900A37B01 /* AesSiv.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AesSiv.swift; sourceTree = "<group>"; };
 		9E44EEA724599C7800A37B01 /* AesSivTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AesSivTests.swift; sourceTree = "<group>"; };
+		9E97DC8C25F77BA40046C83E /* ContentCryptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCryptor.swift; sourceTree = "<group>"; };
 		9E9BB811245412E900F9FF51 /* Cryptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cryptor.swift; sourceTree = "<group>"; };
 		9E9BB8132454708600F9FF51 /* Masterkey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Masterkey.swift; sourceTree = "<group>"; };
 		9E9BB81524558DFF00F9FF51 /* MasterkeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasterkeyTests.swift; sourceTree = "<group>"; };
@@ -157,6 +159,7 @@
 				74F0F7592490C1EB00B4C26D /* CryptoSupport.swift */,
 				9E9BB8132454708600F9FF51 /* Masterkey.swift */,
 				74B4D38C2588CD60006C0567 /* MasterkeyFile.swift */,
+				9E97DC8C25F77BA40046C83E /* ContentCryptor.swift */,
 			);
 			path = CryptomatorCryptoLib;
 			sourceTree = "<group>";
@@ -409,6 +412,7 @@
 				74F0F75A2490C1EB00B4C26D /* CryptoSupport.swift in Sources */,
 				9E9BB8142454708600F9FF51 /* Masterkey.swift in Sources */,
 				9E44EEA624599C6900A37B01 /* AesSiv.swift in Sources */,
+				9E97DC8D25F77BA40046C83E /* ContentCryptor.swift in Sources */,
 				74F0F754248FC89B00B4C26D /* CryptoError.swift in Sources */,
 				74B4D38D2588CD60006C0567 /* MasterkeyFile.swift in Sources */,
 			);

--- a/Sources/CryptomatorCryptoLib/ContentCryptor.swift
+++ b/Sources/CryptomatorCryptoLib/ContentCryptor.swift
@@ -17,6 +17,7 @@ protocol ContentCryptor {
 	 Encrypts one single chunk of cleartext data.
 
 	 - Parameter chunk: The cleartext to be encrypted.
+	 - Parameter key: The encryption key.
 	 - Parameter nonce: The nonce/IV to use.
 	 - Parameter ad: Associated data, which needs to be authenticated during decryption.
 	 - Returns: Nonce/IV + ciphertext + MAC/tag, as a concatenated byte array
@@ -27,6 +28,7 @@ protocol ContentCryptor {
 	 Decrypts one single chunk of encrypted data.
 
 	 - Parameter chunk: The nonce/IV + ciphertext + MAC/tag, as a concatenated byte array.
+	 - Parameter key: The encryption key.
 	 - Parameter ad: Associated data, which needs to be authenticated during decryption.
 	 - Returns: The original cleartext
 	 */

--- a/Sources/CryptomatorCryptoLib/ContentCryptor.swift
+++ b/Sources/CryptomatorCryptoLib/ContentCryptor.swift
@@ -1,0 +1,89 @@
+//
+//  ContentCryptor.swift
+//  CryptomatorCryptoLib
+//
+//  Created by Sebastian Stenzel on 09.03.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+import CommonCrypto
+import Foundation
+
+protocol ContentCryptor {
+    
+    var nonceLen: Int { get }
+    var tagLen: Int { get }
+    
+    /**
+     Encrypts one single chunk of cleartext data.
+
+     - Parameter chunk: The cleartext to be encrypted.
+     - Parameter nonce: The nonce/IV to use.
+     - Parameter ad: Associated data, which needs to be authenticated during decryption.
+     - Returns: Nonce/IV + ciphertext + MAC/tag, as a concatenated byte array
+     */
+    func encrypt(_ chunk: [UInt8], key: [UInt8], nonce: [UInt8], ad: [UInt8]...) throws -> [UInt8]
+    
+    /**
+     Decrypts one single chunk of encrypted data.
+
+     - Parameter chunk: The nonce/IV + ciphertext + MAC/tag, as a concatenated byte array.
+     - Parameter ad: Associated data, which needs to be authenticated during decryption.
+     - Returns: The original cleartext
+     */
+    func decrypt(_ chunk: [UInt8], key: [UInt8], ad: [UInt8]...) throws -> [UInt8]
+}
+
+class CtrThenHmacContentCryptor : ContentCryptor {
+    
+    private let macKey: [UInt8]
+    private let cryptoSupport: CryptoSupport
+    
+    var nonceLen: Int {
+        get {
+            return kCCBlockSizeAES128
+        }
+    }
+    var tagLen: Int {
+        get {
+            return Int(CC_SHA256_DIGEST_LENGTH)
+        }
+    }
+
+    init(macKey: [UInt8], cryptoSupport: CryptoSupport) {
+        self.macKey = macKey
+        self.cryptoSupport = cryptoSupport
+    }
+    
+    func encrypt(_ chunk: [UInt8], key: [UInt8], nonce: [UInt8], ad: [UInt8]...) throws -> [UInt8] {
+        let ciphertext = try AesCtr.compute(key: key, iv: nonce, data: chunk)
+        let mac = computeHmac(ciphertext, nonce: nonce, ad: ad)
+        return nonce + ciphertext + mac
+    }
+    
+    func decrypt(_ chunk: [UInt8], key: [UInt8], ad: [UInt8]...) throws -> [UInt8] {
+        assert(chunk.count >= nonceLen + tagLen, "ciphertext chunk must at least contain nonce + tag")
+
+        // decompose chunk:
+        let beginOfMAC = chunk.count - tagLen
+        let chunkNonce = [UInt8](chunk[0 ..< nonceLen])
+        let ciphertext = [UInt8](chunk[nonceLen ..< beginOfMAC])
+        let expectedMAC = [UInt8](chunk[beginOfMAC...])
+
+        // check MAC:
+        let mac = computeHmac(ciphertext, nonce: chunkNonce, ad: ad)
+        guard cryptoSupport.compareBytes(expected: expectedMAC, actual: mac) else {
+            throw CryptoError.unauthenticCiphertext
+        }
+
+        // decrypt:
+        return try AesCtr.compute(key: key, iv: chunkNonce, data: ciphertext)
+    }
+    
+    private func computeHmac(_ ciphertext: [UInt8], nonce: [UInt8], ad: [[UInt8]]) -> [UInt8] {
+        let data = ad.reduce([UInt8](), +) + nonce + ciphertext
+        var mac = [UInt8](repeating: 0x00, count: tagLen)
+        CCHmac(CCHmacAlgorithm(kCCHmacAlgSHA256), macKey, macKey.count, data, data.count, &mac)
+        return mac
+    }
+}

--- a/Sources/CryptomatorCryptoLib/ContentCryptor.swift
+++ b/Sources/CryptomatorCryptoLib/ContentCryptor.swift
@@ -10,80 +10,75 @@ import CommonCrypto
 import Foundation
 
 protocol ContentCryptor {
-    
-    var nonceLen: Int { get }
-    var tagLen: Int { get }
-    
-    /**
-     Encrypts one single chunk of cleartext data.
+	var nonceLen: Int { get }
+	var tagLen: Int { get }
 
-     - Parameter chunk: The cleartext to be encrypted.
-     - Parameter nonce: The nonce/IV to use.
-     - Parameter ad: Associated data, which needs to be authenticated during decryption.
-     - Returns: Nonce/IV + ciphertext + MAC/tag, as a concatenated byte array
-     */
-    func encrypt(_ chunk: [UInt8], key: [UInt8], nonce: [UInt8], ad: [UInt8]...) throws -> [UInt8]
-    
-    /**
-     Decrypts one single chunk of encrypted data.
+	/**
+	 Encrypts one single chunk of cleartext data.
 
-     - Parameter chunk: The nonce/IV + ciphertext + MAC/tag, as a concatenated byte array.
-     - Parameter ad: Associated data, which needs to be authenticated during decryption.
-     - Returns: The original cleartext
-     */
-    func decrypt(_ chunk: [UInt8], key: [UInt8], ad: [UInt8]...) throws -> [UInt8]
+	 - Parameter chunk: The cleartext to be encrypted.
+	 - Parameter nonce: The nonce/IV to use.
+	 - Parameter ad: Associated data, which needs to be authenticated during decryption.
+	 - Returns: Nonce/IV + ciphertext + MAC/tag, as a concatenated byte array
+	 */
+	func encrypt(_ chunk: [UInt8], key: [UInt8], nonce: [UInt8], ad: [UInt8]...) throws -> [UInt8]
+
+	/**
+	 Decrypts one single chunk of encrypted data.
+
+	 - Parameter chunk: The nonce/IV + ciphertext + MAC/tag, as a concatenated byte array.
+	 - Parameter ad: Associated data, which needs to be authenticated during decryption.
+	 - Returns: The original cleartext
+	 */
+	func decrypt(_ chunk: [UInt8], key: [UInt8], ad: [UInt8]...) throws -> [UInt8]
 }
 
-class CtrThenHmacContentCryptor : ContentCryptor {
-    
-    private let macKey: [UInt8]
-    private let cryptoSupport: CryptoSupport
-    
-    var nonceLen: Int {
-        get {
-            return kCCBlockSizeAES128
-        }
-    }
-    var tagLen: Int {
-        get {
-            return Int(CC_SHA256_DIGEST_LENGTH)
-        }
-    }
+class CtrThenHmacContentCryptor: ContentCryptor {
+	private let macKey: [UInt8]
+	private let cryptoSupport: CryptoSupport
 
-    init(macKey: [UInt8], cryptoSupport: CryptoSupport) {
-        self.macKey = macKey
-        self.cryptoSupport = cryptoSupport
-    }
-    
-    func encrypt(_ chunk: [UInt8], key: [UInt8], nonce: [UInt8], ad: [UInt8]...) throws -> [UInt8] {
-        let ciphertext = try AesCtr.compute(key: key, iv: nonce, data: chunk)
-        let mac = computeHmac(ciphertext, nonce: nonce, ad: ad)
-        return nonce + ciphertext + mac
-    }
-    
-    func decrypt(_ chunk: [UInt8], key: [UInt8], ad: [UInt8]...) throws -> [UInt8] {
-        assert(chunk.count >= nonceLen + tagLen, "ciphertext chunk must at least contain nonce + tag")
+	var nonceLen: Int {
+		return kCCBlockSizeAES128
+	}
 
-        // decompose chunk:
-        let beginOfMAC = chunk.count - tagLen
-        let chunkNonce = [UInt8](chunk[0 ..< nonceLen])
-        let ciphertext = [UInt8](chunk[nonceLen ..< beginOfMAC])
-        let expectedMAC = [UInt8](chunk[beginOfMAC...])
+	var tagLen: Int {
+		return Int(CC_SHA256_DIGEST_LENGTH)
+	}
 
-        // check MAC:
-        let mac = computeHmac(ciphertext, nonce: chunkNonce, ad: ad)
-        guard cryptoSupport.compareBytes(expected: expectedMAC, actual: mac) else {
-            throw CryptoError.unauthenticCiphertext
-        }
+	init(macKey: [UInt8], cryptoSupport: CryptoSupport) {
+		self.macKey = macKey
+		self.cryptoSupport = cryptoSupport
+	}
 
-        // decrypt:
-        return try AesCtr.compute(key: key, iv: chunkNonce, data: ciphertext)
-    }
-    
-    private func computeHmac(_ ciphertext: [UInt8], nonce: [UInt8], ad: [[UInt8]]) -> [UInt8] {
-        let data = ad.reduce([UInt8](), +) + nonce + ciphertext
-        var mac = [UInt8](repeating: 0x00, count: tagLen)
-        CCHmac(CCHmacAlgorithm(kCCHmacAlgSHA256), macKey, macKey.count, data, data.count, &mac)
-        return mac
-    }
+	func encrypt(_ chunk: [UInt8], key: [UInt8], nonce: [UInt8], ad: [UInt8]...) throws -> [UInt8] {
+		let ciphertext = try AesCtr.compute(key: key, iv: nonce, data: chunk)
+		let mac = computeHmac(ciphertext, nonce: nonce, ad: ad)
+		return nonce + ciphertext + mac
+	}
+
+	func decrypt(_ chunk: [UInt8], key: [UInt8], ad: [UInt8]...) throws -> [UInt8] {
+		assert(chunk.count >= nonceLen + tagLen, "ciphertext chunk must at least contain nonce + tag")
+
+		// decompose chunk:
+		let beginOfMAC = chunk.count - tagLen
+		let chunkNonce = [UInt8](chunk[0 ..< nonceLen])
+		let ciphertext = [UInt8](chunk[nonceLen ..< beginOfMAC])
+		let expectedMAC = [UInt8](chunk[beginOfMAC...])
+
+		// check MAC:
+		let mac = computeHmac(ciphertext, nonce: chunkNonce, ad: ad)
+		guard cryptoSupport.compareBytes(expected: expectedMAC, actual: mac) else {
+			throw CryptoError.unauthenticCiphertext
+		}
+
+		// decrypt:
+		return try AesCtr.compute(key: key, iv: chunkNonce, data: ciphertext)
+	}
+
+	private func computeHmac(_ ciphertext: [UInt8], nonce: [UInt8], ad: [[UInt8]]) -> [UInt8] {
+		let data = ad.reduce([UInt8](), +) + nonce + ciphertext
+		var mac = [UInt8](repeating: 0x00, count: tagLen)
+		CCHmac(CCHmacAlgorithm(kCCHmacAlgSHA256), macKey, macKey.count, data, data.count, &mac)
+		return mac
+	}
 }

--- a/Sources/CryptomatorCryptoLib/ContentCryptor.swift
+++ b/Sources/CryptomatorCryptoLib/ContentCryptor.swift
@@ -39,13 +39,8 @@ class CtrThenHmacContentCryptor: ContentCryptor {
 	private let macKey: [UInt8]
 	private let cryptoSupport: CryptoSupport
 
-	var nonceLen: Int {
-		return kCCBlockSizeAES128
-	}
-
-	var tagLen: Int {
-		return Int(CC_SHA256_DIGEST_LENGTH)
-	}
+	let nonceLen = kCCBlockSizeAES128
+	let tagLen = Int(CC_SHA256_DIGEST_LENGTH)
 
 	init(macKey: [UInt8], cryptoSupport: CryptoSupport) {
 		self.macKey = macKey

--- a/Tests/CryptomatorCryptoLibTests/CryptorTests.swift
+++ b/Tests/CryptomatorCryptoLibTests/CryptorTests.swift
@@ -10,11 +10,18 @@ import XCTest
 @testable import CryptomatorCryptoLib
 
 class CryptorTests: XCTestCase {
-	let cryptor = Cryptor(masterkey: Masterkey.createFromRaw(aesMasterKey: [UInt8](repeating: 0x55, count: 32), macMasterKey: [UInt8](repeating: 0x77, count: 32)), cryptoSupport: CryptoSupportMock())
+    var cryptor: Cryptor!
 	var tmpDirURL: URL!
 
 	override func setUpWithError() throws {
-		tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true).appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let aesKey = [UInt8](repeating: 0x55, count: 32)
+        let macKey = [UInt8](repeating: 0x77, count: 32)
+        let masterkey = Masterkey.createFromRaw(aesMasterKey: aesKey, macMasterKey: macKey)
+        let cryptoSupport = CryptoSupportMock()
+        let contentCryptor = CtrThenHmacContentCryptor(macKey: macKey, cryptoSupport: cryptoSupport)
+        cryptor = Cryptor(masterkey: masterkey, cryptoSupport: cryptoSupport, contentCryptor: contentCryptor)
+        
+        tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true).appendingPathComponent(UUID().uuidString, isDirectory: true)
 		try FileManager.default.createDirectory(at: tmpDirURL, withIntermediateDirectories: true)
 	}
 

--- a/Tests/CryptomatorCryptoLibTests/CryptorTests.swift
+++ b/Tests/CryptomatorCryptoLibTests/CryptorTests.swift
@@ -10,18 +10,18 @@ import XCTest
 @testable import CryptomatorCryptoLib
 
 class CryptorTests: XCTestCase {
-    var cryptor: Cryptor!
+	var cryptor: Cryptor!
 	var tmpDirURL: URL!
 
 	override func setUpWithError() throws {
-        let aesKey = [UInt8](repeating: 0x55, count: 32)
-        let macKey = [UInt8](repeating: 0x77, count: 32)
-        let masterkey = Masterkey.createFromRaw(aesMasterKey: aesKey, macMasterKey: macKey)
-        let cryptoSupport = CryptoSupportMock()
-        let contentCryptor = CtrThenHmacContentCryptor(macKey: macKey, cryptoSupport: cryptoSupport)
-        cryptor = Cryptor(masterkey: masterkey, cryptoSupport: cryptoSupport, contentCryptor: contentCryptor)
-        
-        tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true).appendingPathComponent(UUID().uuidString, isDirectory: true)
+		let aesKey = [UInt8](repeating: 0x55, count: 32)
+		let macKey = [UInt8](repeating: 0x77, count: 32)
+		let masterkey = Masterkey.createFromRaw(aesMasterKey: aesKey, macMasterKey: macKey)
+		let cryptoSupport = CryptoSupportMock()
+		let contentCryptor = CtrThenHmacContentCryptor(macKey: macKey, cryptoSupport: cryptoSupport)
+		cryptor = Cryptor(masterkey: masterkey, cryptoSupport: cryptoSupport, contentCryptor: contentCryptor)
+
+		tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true).appendingPathComponent(UUID().uuidString, isDirectory: true)
 		try FileManager.default.createDirectory(at: tmpDirURL, withIntermediateDirectories: true)
 	}
 


### PR DESCRIPTION
`Cryptor` now has a `ContentCryptor` parameter, that eventually allows use of other cipher configurations.

As other configurations may result in different ciphertext/cleartext ratios (due to different IV/Nonce or MAC/tag length), the size calculations no longer depend on constants declared inside of `Cryptor` but rather use values returned from `ContentCryptor.nonceLen` and `ContentCryptor.tagLen`.

Note that `ContentCryptor` is not yet public. Depending on the API used to choose the cipher, we might want to expose this class. Alternatively we could add a public enum that knows what ContentCryptor to provide.